### PR TITLE
fix build query string in Request::send()

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -284,11 +284,7 @@ class Request extends Message implements RequestInterface
         if (in_array($this->getMethod(), ['PUT', 'POST', 'DELETE', 'PATCH', 'OPTIONS'])) {
             $this->withOption(CURLOPT_POSTFIELDS, $data);
         } else if (!empty($data)) {
-            $concat = '?';
-            if (false === strpos($url, '?')) {
-                $concat = '&';
-            }
-            $url .= $concat . $data;
+            $url .= (false === strpos($url, '?') ? '?' : '&') . $data;
         }
 
         $this->withOption(CURLOPT_USERAGENT, static::USER_AGENT);


### PR DESCRIPTION
当 `method` 为 `GET` 时,
```
$concat = '?';
if (false === strpos($url, '?')) {
    $concat = '&';
}
```
应该是
```
$concat = '?';
if (false !== strpos($url, '?')) {
    $concat = '&';
}
```