### PR TITLE
add support raw data payload to httppost request

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -270,16 +270,16 @@ class Request extends Message implements RequestInterface
     }
 
     /**
-     * @param array $data
+     * @param array|string $data
      * @param array $headers
      * @return Response
      */
-    public function send(array $data = [], array $headers = [])
+    public function send($data = [], array $headers = [])
     {
         $ch = curl_init();
         $url = (string)$this->uri;
 
-        $data = http_build_query($data);
+        is_array($data) && $data = http_build_query($data);
 
         if (in_array($this->getMethod(), ['PUT', 'POST', 'DELETE', 'PATCH', 'OPTIONS'])) {
             $this->withOption(CURLOPT_POSTFIELDS, $data);

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -53,4 +53,12 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $response = $request->send();
         $this->assertEquals(200, $response->getStatusCode());
     }
+
+    public function testPostRawRequest()
+    {
+        $raw = '<xml><appid><![CDATA[123456789123456789]]></appid><mch_id>1234567890</mch_id><nonce_str><![CDATA[589d897212f9c]]></nonce_str><body><![CDATA[123]]></body><out_trade_no><![CDATA[runnerlee_001]]></out_trade_no><fee_type><![CDATA[CNY]]></fee_type><total_fee>1</total_fee><spbill_create_ip><![CDATA[127.0.0.1]]></spbill_create_ip><trade_type><![CDATA[NATIVE]]></trade_type><notify_url><![CDATA[http://github.com]]></notify_url><detail><![CDATA[runnerlee_test_payment]]></detail><sign><![CDATA[ZXCVBNMASDFGHJKLQWERTYUIOP123456]]></sign></xml>';
+        $request = new Request('POST', 'https://api.mch.weixin.qq.com/pay/unifiedorder');
+        $response = (array)simplexml_load_string($request->send($raw)->getContents(), 'SimpleXMLElement', LIBXML_NOCDATA);
+        $this->assertEquals('appid不存在', $response['return_msg']);
+    }
 }


### PR DESCRIPTION
添加支持提交 post 原生数据, 并添加对应单元测试, 以随机信息请求微信统一下单接口为例, 返回 appid 不存在错误信息