### PR TITLE
修复 Request::send() 解析response header 错误

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -315,7 +315,7 @@ class Request extends Message implements RequestInterface
         array_shift($responseHeaders);
         $headers = [];
         array_map(function ($headerLine) use (&$headers) {
-            list($key, $value) = explode(':', $headerLine);
+            list($key, $value) = explode(':', $headerLine, 2);
             $headers[$key] = trim($value);
             unset($headerLine, $key, $value);
         }, $responseHeaders);


### PR DESCRIPTION
例如响应头里有
```
Location: https://github.com
```
就会出现拿不到完整的跳转路径