### PR TITLE
更新设置请求头

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -104,7 +104,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     {
         array_walk($server, function ($value, $key) {
             if (0 === strpos($key, 'HTTP_')) {
-                $this->withAddedHeader($key, $value);
+                $this->withAddedHeader(str_replace('HTTP_', '', $key), $value);
             }
         });
 

--- a/src/SwooleServerRequest.php
+++ b/src/SwooleServerRequest.php
@@ -65,13 +65,19 @@ class SwooleServerRequest extends ServerRequest
             'HTTP_CACHE_CONTROL' => isset($request->header['cache-control']) ? $request->header['cache-control'] : '',
         ];
 
+        $headers = [];
+        foreach ($request->header as $name => $value) {
+            $headers[str_replace('-', '_', $name)] = $value;
+        }
+
         $serverRequest = new ServerRequest(
             $server['REQUEST_METHOD'],
             static::createUriFromGlobal($server),
-            $request->header,
+            $request,
             null,
             $server
         );
+        unset($headers);
 
         $serverRequest->getBody()->write($request->rawContent());
 

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -109,6 +109,36 @@ class ServerRequestTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    public function dataHeadersFromGlobals()
+    {
+        return [
+            'accept' => [
+                'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            ],
+            'accept_charset' => [
+                'ISO-8859-1,utf-8;q=0.7,*;q=0.7',
+            ],
+            'accept_encoding' => [
+                'gzip,deflate',
+            ],
+            'accept_language' => [
+                'en-gb,en;q=0.5',
+            ],
+            'connection' => [
+                'keep-alive',
+            ],
+            'host' => [
+                'www.blakesimpson.co.uk',
+            ],
+            'referer' => [
+                'http://previous.url.com',
+            ],
+            'user_agent' => [
+                'Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.9.2.6) Gecko/20100625 Firefox/3.6.6 ( .NET CLR 3.5.30729)',
+            ],
+        ];
+    }
+
     public function dataPUTServerFromGlobals()
     {
         return  [
@@ -185,6 +215,7 @@ class ServerRequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($this->dataCookiesFromGlobals(), $serverRequest->getCookieParams());
         $this->assertEquals($this->dataCookiesFromGlobals(), $serverRequest->getCookieParams());
         $this->assertEquals($this->dataBodyFromGlobals(), $serverRequest->getParsedBody());
+        $this->assertEquals($this->dataHeadersFromGlobals(), $serverRequest->getHeaders());
     }
 
     public function testSerRequestFromGlobalsIsMethodPUT()


### PR DESCRIPTION
原来在 swoole 模式下, 通过 `swoole_http_request::$header` 拿到的请求头里, 连接符是用`-`, 而在 fpm 模式下通过 `$_SERVER` 拿到的自定义请求头连接符是用 `_`, 且带有 `HTTP_` 前缀.

修改为全部采用`_`, 并且去掉 fpm 模式下 的 `HTTP_` 前缀