### PR TITLE
修复 Request::withOptions() 键名被重新编号

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -240,7 +240,7 @@ class Request extends Message implements RequestInterface
      */
     public function withOptions(array $options)
     {
-        $this->options = array_merge($this->options, $options);
+        $this->options = $options + $this->options;
 
         return $this;
     }
@@ -287,7 +287,9 @@ class Request extends Message implements RequestInterface
             $url .= (false === strpos($url, '?') ? '?' : '&') . $data;
         }
 
-        $this->withOption(CURLOPT_USERAGENT, static::USER_AGENT);
+        if (!array_key_exists(CURLOPT_USERAGENT, $this->options)) {
+            $this->withOption(CURLOPT_USERAGENT, static::USER_AGENT);
+        }
         $this->withOption(CURLOPT_HTTPHEADER, $headers);
         $this->withOption(CURLOPT_URL, $url);
         $this->withOption(CURLOPT_CUSTOMREQUEST, $this->getMethod());

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -81,4 +81,30 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $response = (array)simplexml_load_string($request->send($raw)->getContents(), 'SimpleXMLElement', LIBXML_NOCDATA);
         $this->assertEquals('appid不存在', $response['return_msg']);
     }
+
+    public function testWithOptions()
+    {
+        $request = new Request('GET', '/');
+        $request->withOptions([
+            CURLOPT_CONNECTTIMEOUT => 30,
+            CURLOPT_USERAGENT => 'Hello World',
+        ]);
+        $this->assertEquals(
+            [
+                CURLOPT_CONNECTTIMEOUT => 30,
+                CURLOPT_USERAGENT => 'Hello World',
+            ],
+            $request->getOptions()
+        );
+        $request->withOptions([
+            CURLOPT_CONNECTTIMEOUT => 20,
+        ]);
+        $this->assertEquals(
+            [
+                CURLOPT_CONNECTTIMEOUT => 20,
+                CURLOPT_USERAGENT => 'Hello World',
+            ],
+            $request->getOptions()
+        );
+    }
 }


### PR DESCRIPTION
原先在 `Request::withOptions()` 中是使用 `array_merge()` 合并两个数组, 而 curl 选项常量值是数字, 使用 `array_merge` 合并两个数组会被导致重新编号. 导致出错.

例如
```
$request->withOptions([
    78 => 30, // CURLOPT_CONNECTTIMEOUT
])
```

最终 `Request::$options` 会变成
```
[
    0 => 30,
]
```