### PR TITLE
格式化请求头, 将 "-" 替换为"_"

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -519,6 +519,12 @@ class ServerRequest extends Request implements ServerRequestInterface
         $method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET';
         $headers = function_exists('getallheaders') ? getallheaders() : [];
 
+        foreach ($headers as $name => $value) {
+            $name = str_replace('-', '_', $name);
+            unset($headers[$name]);
+            $headers[$name] = $value;
+        }
+
         return new static($method, static::createUriFromGlobal($_SERVER), $headers, new PhpInputStream(), $_SERVER);
     }
 }

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -520,8 +520,8 @@ class ServerRequest extends Request implements ServerRequestInterface
         $headers = function_exists('getallheaders') ? getallheaders() : [];
 
         foreach ($headers as $name => $value) {
-            $name = str_replace('-', '_', $name);
             unset($headers[$name]);
+            $name = str_replace('-', '_', $name);
             $headers[$name] = $value;
         }
 


### PR DESCRIPTION
使用 php 内置的 webserver 时, `getallheaders()` 获取到的请求头是使用 `-`的, 而通过 fpm 或 swoole 则是 `_`. 建议强制转换为 `_`.