### PR TITLE
格式化请求头, 将 "-" 替换为 "_" in 3.0

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -519,6 +519,12 @@ class ServerRequest extends Request implements ServerRequestInterface
         $method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET';
         $headers = function_exists('getallheaders') ? getallheaders() : [];
 
+        foreach ($headers as $name => $value) {
+            unset($headers[$name]);
+            $name = str_replace('-', '_', $name);
+            $headers[$name] = $value;
+        }
+
         return new static($method, static::createUriFromGlobal($_SERVER), $headers, new PhpInputStream(), $_SERVER);
     }
 }


### PR DESCRIPTION
参见 #19 