### PR TITLE
处理 http 100 continue 的情况

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -310,8 +310,15 @@ class Request extends Message implements RequestInterface
         }
 
         $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch); unset($ch);
-        list($responseHeaders, $response) = explode("\r\n\r\n", $response, 2);
+        curl_close($ch);
+        unset($ch);
+        // handle 100 continue message
+        // see: https://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html#sec8.2.3
+        // see: https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Status/100
+        // see: https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/Expect
+        $responseInfo = explode("\r\n\r\n", $response);
+        $response = array_pop($responseInfo);
+        $responseHeaders = array_pop($responseInfo);
         $responseHeaders = preg_split('/\r\n/', $responseHeaders, null, PREG_SPLIT_NO_EMPTY);
 
         array_shift($responseHeaders);

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -54,6 +54,18 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
+    public function testRequestWithLargeBody()
+    {
+        $request = new Request('POST', 'https://passport.baidu.com/v2/api/?login');
+
+        $response = $request->send([
+            'a' => str_repeat('10000', 10000),
+        ]);
+
+        $this->assertSame(true, count($response->getHeaders()) > 0);
+        $this->assertSame(302, $response->getStatusCode());
+    }
+
     public function testResponseWithEncoding()
     {
         $request = $this->server();


### PR DESCRIPTION
同: https://github.com/fastdlabs/http/commit/4be3d6fd913f63f357dae037f52d42da2fe4c0a1

应用到 3.0 版本的修复