### PR TITLE
修复解析 response 异常

### DIFF
--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -54,6 +54,18 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
+    public function testRequestWithLargeBody()
+    {
+        $request = new Request('POST', 'https://github.com/session');
+
+        $response = $request->send([
+            'a' => str_repeat('11111', 1000),
+        ]);
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('GitHub.com', $response->getHeader('server')[0]);
+    }
+
     public function testResponseWithEncoding()
     {
         $request = $this->server();


### PR DESCRIPTION
前面的这个修复: https://github.com/fastdlabs/http/commit/4be3d6fd913f63f357dae037f52d42da2fe4c0a1

当 response body 存在 `\r\n\r\n` 的内容时, 会造成解析错误.

多个响应头的情况, 正常情况应该只有 100 continue 的时候才有, 207 的情况不清楚. 或是自定义响应头的时候写多了.

因此改回去原先的解析方式, 并强制发送空的 `Expect` 头以解决 100 的情况.

同时修改 `OPTIONS` 方法不能发送 body. 参考: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS